### PR TITLE
added unixodbc dependency

### DIFF
--- a/whale.rb
+++ b/whale.rb
@@ -8,6 +8,7 @@ class Whale < Formula
   version "v1.5.1"
 
   depends_on "python@3.8"
+  depends_on "unixodbc"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Added a dependency for `unixodbc` to the whale homebrew formulae to prevent the issues experienced here:

[https://github.com/dataframehq/whale/issues/152](https://github.com/dataframehq/whale/issues/152)
[https://github.com/dataframehq/whale/issues/139](https://github.com/dataframehq/whale/issues/139)